### PR TITLE
fix(plugin-github): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/github/actions/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/actions/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Actions",
+    title = "GitHub Actions",
     description = "This sub-group of plugins contains tasks for triggering and managing GitHub Actions workflows.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/code/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/code/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Code",
+    title = "GitHub Code",
     description = "This sub-group of plugins contains tasks for accessing and managing source code using Github API.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/commits/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/commits/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Commits",
+    title = "GitHub Commits",
     description = "This sub-group of plugins contains to manage github commits.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/issues/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/issues/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Issues",
+    title = "GitHub Issues",
     description = "This sub-group of plugins contains tasks for managing GitHub issues.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/pulls/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/pulls/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Pull Requests",
+    title = "GitHub Pull Requests",
     description = "This sub-group of plugins contains tasks for managing pull requests in GitHub.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/repositories/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/repositories/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Repositories",
+    title = "GitHub Repositories",
     description = "This sub-group of plugins contains tasks for managing GitHub repositories.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/github/topics/package-info.java
+++ b/src/main/java/io/kestra/plugin/github/topics/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Topics",
+    title = "GitHub Topics",
     description = "This sub-group of plugins contains tasks for managing Github topics.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge