### PR TITLE
fix(core): migrate FileSerde reads to InputStream API for binary ION

### DIFF
--- a/src/main/java/io/kestra/plugin/github/AbstractGithubSearchTask.java
+++ b/src/main/java/io/kestra/plugin/github/AbstractGithubSearchTask.java
@@ -54,8 +54,7 @@ public abstract class AbstractGithubSearchTask extends AbstractGithubTask {
             case STORE:
                 File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-                try (BufferedOutputStream output =
-                         new BufferedOutputStream(new FileOutputStream(tempFile))) {
+                try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
 
                     for (Map<String, Object> item : mapped) {
                         FileSerde.write(output, item);

--- a/src/test/java/io/kestra/plugin/github/code/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/code/SearchTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubClientTest;
@@ -11,10 +12,8 @@ import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -72,10 +71,11 @@ public class SearchTest extends AbstractGithubClientTest {
         assertThat(result.getFirst().get("repository_name"), is("plugin-github"));
     }
 
+    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/commits/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/commits/SearchTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubClientTest;
@@ -11,10 +12,8 @@ import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -72,10 +71,11 @@ public class SearchTest extends AbstractGithubClientTest {
         assertThat(result.getFirst().get("message"), is("Initial commit"));
     }
 
+    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/issues/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/issues/SearchTest.java
@@ -5,16 +5,15 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -95,9 +94,9 @@ public class SearchTest {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/pulls/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/pulls/SearchTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubClientTest;
@@ -12,10 +13,8 @@ import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -101,9 +100,9 @@ public class SearchTest extends AbstractGithubClientTest {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/repositories/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/repositories/SearchTest.java
@@ -5,16 +5,15 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -97,9 +96,9 @@ public class SearchTest {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/topics/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/topics/SearchTest.java
@@ -4,6 +4,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubClientTest;
@@ -12,10 +13,8 @@ import io.kestra.plugin.github.MockController;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -78,9 +77,9 @@ public class SearchTest extends AbstractGithubClientTest {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/github/users/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/github/users/SearchTest.java
@@ -5,6 +5,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.github.AbstractGithubClientTest;
@@ -12,10 +13,8 @@ import io.kestra.plugin.github.AbstractGithubSearchTask;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -76,9 +75,9 @@ public class SearchTest extends AbstractGithubClientTest {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getResult(AbstractGithubSearchTask.Output run) throws IOException {
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
-        return result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri()))) {
+            var iterator = JacksonMapper.ofIon().readerFor(Object.class).readValues(inputStream);
+            return (List) FileSerde.readAll(iterator).collectList().block();
+        }
     }
 }


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.