### PR TITLE
feat(issues): add support for Issue Field values via GitHub REST API

### DIFF
--- a/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
+++ b/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
@@ -67,17 +67,17 @@ public abstract class AbstractGithubTask extends Task {
     }
 
     protected String resolveToken(RunContext runContext) throws Exception {
-        var rendered = runContext.render(this.oauthToken).as(String.class).orElse(null);
-        if (rendered != null) {
-            return rendered;
+        var rToken = runContext.render(this.oauthToken).as(String.class).orElse(null);
+        if (rToken != null) {
+            return rToken;
         }
-        rendered = runContext.render(this.appInstallationToken).as(String.class).orElse(null);
-        if (rendered != null) {
-            return rendered;
+        rToken = runContext.render(this.appInstallationToken).as(String.class).orElse(null);
+        if (rToken != null) {
+            return rToken;
         }
-        rendered = runContext.render(this.jwtToken).as(String.class).orElse(null);
-        if (rendered != null) {
-            return rendered;
+        rToken = runContext.render(this.jwtToken).as(String.class).orElse(null);
+        if (rToken != null) {
+            return rToken;
         }
         throw new IllegalStateException("No GitHub token configured: set oauthToken, appInstallationToken, or jwtToken");
     }

--- a/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
+++ b/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
@@ -67,15 +67,21 @@ public abstract class AbstractGithubTask extends Task {
     }
 
     protected String resolveToken(RunContext runContext) throws Exception {
-        var rToken = runContext.render(this.oauthToken).as(String.class).orElse(null);
+        var rToken = runContext.render(this.oauthToken).as(String.class)
+            .filter(s -> !s.isBlank())
+            .orElse(null);
         if (rToken != null) {
             return rToken;
         }
-        rToken = runContext.render(this.appInstallationToken).as(String.class).orElse(null);
+        rToken = runContext.render(this.appInstallationToken).as(String.class)
+            .filter(s -> !s.isBlank())
+            .orElse(null);
         if (rToken != null) {
             return rToken;
         }
-        rToken = runContext.render(this.jwtToken).as(String.class).orElse(null);
+        rToken = runContext.render(this.jwtToken).as(String.class)
+            .filter(s -> !s.isBlank())
+            .orElse(null);
         if (rToken != null) {
             return rToken;
         }

--- a/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
+++ b/src/main/java/io/kestra/plugin/github/AbstractGithubTask.java
@@ -66,6 +66,22 @@ public abstract class AbstractGithubTask extends Task {
         return appInstallationToken;
     }
 
+    protected String resolveToken(RunContext runContext) throws Exception {
+        var rendered = runContext.render(this.oauthToken).as(String.class).orElse(null);
+        if (rendered != null) {
+            return rendered;
+        }
+        rendered = runContext.render(this.appInstallationToken).as(String.class).orElse(null);
+        if (rendered != null) {
+            return rendered;
+        }
+        rendered = runContext.render(this.jwtToken).as(String.class).orElse(null);
+        if (rendered != null) {
+            return rendered;
+        }
+        throw new IllegalStateException("No GitHub token configured: set oauthToken, appInstallationToken, or jwtToken");
+    }
+
     protected GitHub connect(final RunContext runContext) throws Exception {
         GitHubBuilder builder = new GitHubBuilder();
 

--- a/src/main/java/io/kestra/plugin/github/issues/Create.java
+++ b/src/main/java/io/kestra/plugin/github/issues/Create.java
@@ -3,9 +3,11 @@ package io.kestra.plugin.github.issues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.github.AbstractGithubTask;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -19,9 +21,10 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -96,7 +99,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                    """
         ),
         @Example(
-            title = "Create an issue and set custom Issue Field values.",
+            title = "Create an issue and set custom Issue Field values using human-readable field names.",
             full = true,
             code = """
                    id: github_issue_create_with_fields_flow
@@ -111,9 +114,9 @@ import io.kestra.core.models.annotations.PluginProperty;
                        body: "Created by Kestra workflow {{ execution.id }}"
                        labels:
                          - automation
-                       fieldValues:
-                         PVTF_lADOA: "high"
-                         PVTF_lADOB: "2024-12-31"
+                       fields:
+                         Customer: "Kestra"
+                         Stage: "In review"
                    """
         )
     }
@@ -130,7 +133,7 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
         title = "Issue title",
         description = "Short summary shown in GitHub."
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @Schema(
@@ -158,17 +161,22 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
         title = "Issue field values",
         description = """
             Custom field values to set on the issue after creation, using the GitHub Issues field-values API \
-            (API version `2026-03-10`). The map keys are field node IDs and the values are the field values \
-            to set. Unsupported value types are passed through as-is; GitHub will return a 422 if the type \
-            is invalid. Requires a token with the `project` scope in addition to `issues: write`. \
+            (API version `2026-03-10`). Only available for organization repositories — personal repositories \
+            always return HTTP 404. \
+            Keys can be either human-readable field names (e.g. `"Customer"`, `"Stage"`) or field node IDs \
+            (e.g. `PVTF_…`). Human-readable names are resolved automatically to node IDs via the GitHub API \
+            (`GET /orgs/{org}/issues/field-definitions`). \
+            Values are the field values to set. Unsupported value types are passed through as-is; \
+            GitHub will return a 422 if the type is invalid. \
+            Requires a token with the `project` scope in addition to `issues: write`. \
             When null or empty the REST call is skipped entirely and existing behavior is preserved.\
             """
     )
     @PluginProperty(group = "advanced")
-    private Property<Map<String, Object>> fieldValues;
+    private Property<Map<String, Object>> fields;
 
     private static final String FIELD_VALUES_API_VERSION = "2026-03-10";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapper.ofJson();
 
     @Override
     public Create.Output run(RunContext runContext) throws Exception {
@@ -191,12 +199,12 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
 
         GHIssue issue = issueBuilder.create();
 
-        var rFieldValues = this.fieldValues != null
-            ? runContext.render(this.fieldValues).asMap(String.class, Object.class)
+        var rFields = this.fields != null
+            ? runContext.render(this.fields).asMap(String.class, Object.class)
             : Map.<String, Object>of();
 
-        if (!rFieldValues.isEmpty()) {
-            setFieldValues(runContext, issue, rFieldValues);
+        if (!rFields.isEmpty()) {
+            setFields(runContext, issue, rFields);
         }
 
         return Output
@@ -206,36 +214,194 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
             .build();
     }
 
-    private void setFieldValues(RunContext runContext, GHIssue issue, Map<String, Object> fieldValues) throws Exception {
+    private void setFields(RunContext runContext, GHIssue issue, Map<String, Object> fields) throws Exception {
         var token = resolveToken(runContext);
         var rEndpoint = runContext.render(getEndpoint()).as(String.class)
             .orElse("https://api.github.com");
         var rRepository = runContext.render(this.repository).as(String.class).orElseThrow();
+        var org = rRepository.split("/")[0];
+
+        // Resolve human-readable field names to node IDs when needed
+        var resolvedFields = resolveFieldKeys(runContext, fields, token, rEndpoint, org);
 
         var url = "%s/repos/%s/issues/%d/field-values".formatted(
             rEndpoint.stripTrailing(),
             rRepository,
             issue.getNumber()
         );
-        var body = OBJECT_MAPPER.writeValueAsString(Map.of("field_values", fieldValues));
+        var bodyJson = OBJECT_MAPPER.writeValueAsString(Map.of("field_values", resolvedFields));
 
-        var request = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .header("Authorization", "Bearer " + token)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
-            .PUT(HttpRequest.BodyPublishers.ofString(body))
-            .build();
+        try (var client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build()) {
+            var request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .method("PUT", HttpRequest.BodyPublishers.ofString(bodyJson))
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                runContext.logger().error("Failed to set field values on issue {} (HTTP {}): {}",
+                    issue.getHtmlUrl(), response.statusCode(),
+                    response.body().length() > 500 ? response.body().substring(0, 500) + "…" : response.body());
+                throw new RuntimeException(
+                    "Failed to set field values on issue %s (HTTP %d) — see execution logs for details"
+                        .formatted(issue.getHtmlUrl(), response.statusCode())
+                );
+            }
+        }
+    }
 
-        var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    /**
+     * For each key in the input map: if it looks like a node ID (length > 20 and contains only
+     * ASCII letters, digits, underscores, hyphens), pass it through unchanged. Otherwise treat it
+     * as a human-readable name and resolve it to a field node ID via the GitHub API.
+     */
+    private Map<String, Object> resolveFieldKeys(
+            RunContext runContext,
+            Map<String, Object> fields,
+            String token,
+            String endpoint,
+            String org) throws Exception {
 
-        if (response.statusCode() < 200 || response.statusCode() >= 300) {
-            throw new RuntimeException(
-                "Failed to set field values on issue %s (HTTP %d): %s"
-                    .formatted(issue.getHtmlUrl(), response.statusCode(), response.body())
+        var needsResolution = fields.keySet().stream().anyMatch(k -> !looksLikeNodeId(k));
+        if (!needsResolution) {
+            return fields;
+        }
+
+        var fieldDefs = fetchFieldDefinitions(runContext, token, endpoint, org);
+        var resolved = new HashMap<String, Object>(fields.size());
+        for (var entry : fields.entrySet()) {
+            var key = entry.getKey();
+            if (looksLikeNodeId(key)) {
+                resolved.put(key, entry.getValue());
+            } else {
+                var nodeId = fieldDefs.get(key);
+                if (nodeId == null) {
+                    var available = String.join(", ", fieldDefs.keySet());
+                    throw new IllegalArgumentException(
+                        "Unknown field name '%s' in organization '%s'. Available fields: [%s].".formatted(key, org, available)
+                    );
+                }
+                resolved.put(nodeId, entry.getValue());
+            }
+        }
+        return resolved;
+    }
+
+    private static boolean looksLikeNodeId(String key) {
+        return key.length() > 20 && key.chars().allMatch(c ->
+            (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            (c >= '0' && c <= '9') || c == '_' || c == '-'
+        );
+    }
+
+    /**
+     * Fetches field definitions from the GitHub org-level REST endpoint. Falls back to GraphQL
+     * if the REST endpoint returns 404. Throws if neither endpoint provides definitions.
+     */
+    private Map<String, String> fetchFieldDefinitions(
+            RunContext runContext,
+            String token,
+            String endpoint,
+            String org) throws Exception {
+
+        try (var client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build()) {
+
+            var restUrl = "%s/orgs/%s/issues/field-definitions".formatted(endpoint.stripTrailing(), org);
+            var restRequest = HttpRequest.newBuilder()
+                .uri(URI.create(restUrl))
+                .GET()
+                .header("Authorization", "Bearer " + token)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+            var restResponse = client.send(restRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (restResponse.statusCode() == 200) {
+                return parseRestFieldDefinitions(restResponse.body());
+            }
+
+            if (restResponse.statusCode() == 404) {
+                runContext.logger().debug(
+                    "Field definitions REST endpoint not available for org '{}', trying GraphQL fallback", org);
+                return fetchFieldDefinitionsViaGraphQL(client, token, endpoint, org);
+            }
+
+            throw new IllegalArgumentException(
+                "Cannot resolve field name: field definitions endpoint returned HTTP %d for organization '%s'. Use the field node ID directly (e.g. PVTF_…)."
+                    .formatted(restResponse.statusCode(), org)
             );
         }
+    }
+
+    private Map<String, String> parseRestFieldDefinitions(String body) throws Exception {
+        var root = OBJECT_MAPPER.readTree(body);
+        var result = new HashMap<String, String>();
+        var items = root.isArray() ? root : root.path("field_definitions");
+        for (var node : items) {
+            var name = node.path("name").asText(null);
+            var id = node.path("id").asText(null);
+            if (name != null && id != null) {
+                result.put(name, id);
+            }
+        }
+        return result;
+    }
+
+    private Map<String, String> fetchFieldDefinitionsViaGraphQL(
+            HttpClient client,
+            String token,
+            String endpoint,
+            String org) throws Exception {
+
+        var graphqlEndpoint = endpoint.contains("api.github.com")
+            ? "https://api.github.com/graphql"
+            : endpoint.stripTrailing() + "/graphql";
+        var query = OBJECT_MAPPER.writeValueAsString(Map.of(
+            "query", "query($org: String!) { organization(login: $org) { issueTypes { nodes { id name } } } }",
+            "variables", Map.of("org", org)
+        ));
+        var graphqlRequest = HttpRequest.newBuilder()
+            .uri(URI.create(graphqlEndpoint))
+            .POST(HttpRequest.BodyPublishers.ofString(query))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .timeout(Duration.ofSeconds(30))
+            .build();
+        var graphqlResponse = client.send(graphqlRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (graphqlResponse.statusCode() == 404) {
+            throw new IllegalArgumentException(
+                "Cannot resolve field name: field definitions are not available for organization '%s'. Use the field node ID directly (e.g. PVTF_…).".formatted(org)
+            );
+        }
+
+        var root = OBJECT_MAPPER.readTree(graphqlResponse.body());
+        var nodes = root.path("data").path("organization").path("issueTypes").path("nodes");
+        var result = new HashMap<String, String>();
+        for (var node : nodes) {
+            var name = node.path("name").asText(null);
+            var id = node.path("id").asText(null);
+            if (name != null && id != null) {
+                result.put(name, id);
+            }
+        }
+
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Cannot resolve field name: field definitions are not available for organization '%s'. Use the field node ID directly (e.g. PVTF_…).".formatted(org)
+            );
+        }
+        return result;
     }
 
     @Builder

--- a/src/main/java/io/kestra/plugin/github/issues/Create.java
+++ b/src/main/java/io/kestra/plugin/github/issues/Create.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.github.issues;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.property.Property;
@@ -13,8 +14,13 @@ import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueBuilder;
 import org.kohsuke.github.GitHub;
 
+import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Map;
 import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
@@ -49,6 +55,7 @@ import io.kestra.core.models.annotations.PluginProperty;
         ),
         @Example(
             title = "Create an issue in a repository using OAuth token.",
+            full = true,
             code = """
                    id: github_issue_create_flow
                    namespace: company.team
@@ -68,6 +75,7 @@ import io.kestra.core.models.annotations.PluginProperty;
         ),
         @Example(
             title = "Create an issue in a repository with assignees.",
+            full = true,
             code = """
                    id: github_issue_create_flow
                    namespace: company.team
@@ -85,6 +93,27 @@ import io.kestra.core.models.annotations.PluginProperty;
                        assignees:
                          - MyDeveloperUserName
                          - MyDesignerUserName
+                   """
+        ),
+        @Example(
+            title = "Create an issue and set custom Issue Field values.",
+            full = true,
+            code = """
+                   id: github_issue_create_with_fields_flow
+                   namespace: company.team
+
+                   tasks:
+                     - id: create_issue
+                       type: io.kestra.plugin.github.issues.Create
+                       oauthToken: "{{ secret('GITHUB_ACCESS_TOKEN') }}"
+                       repository: kestra-io/kestra
+                       title: Automated issue with custom fields
+                       body: "Created by Kestra workflow {{ execution.id }}"
+                       labels:
+                         - automation
+                       fieldValues:
+                         PVTF_lADOA: "high"
+                         PVTF_lADOB: "2024-12-31"
                    """
         )
     }
@@ -125,6 +154,22 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
     @PluginProperty(group = "advanced")
     private Property<List<String>> assignees;
 
+    @Schema(
+        title = "Issue field values",
+        description = """
+            Custom field values to set on the issue after creation, using the GitHub Issues field-values API \
+            (API version `2026-03-10`). The map keys are field node IDs and the values are the field values \
+            to set. Unsupported value types are passed through as-is; GitHub will return a 422 if the type \
+            is invalid. Requires a token with the `project` scope in addition to `issues: write`. \
+            When null or empty the REST call is skipped entirely and existing behavior is preserved.\
+            """
+    )
+    @PluginProperty(group = "advanced")
+    private Property<Map<String, Object>> fieldValues;
+
+    private static final String FIELD_VALUES_API_VERSION = "2026-03-10";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Override
     public Create.Output run(RunContext runContext) throws Exception {
         GitHub gitHub = connect(runContext);
@@ -146,11 +191,51 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
 
         GHIssue issue = issueBuilder.create();
 
+        var renderedFieldValues = this.fieldValues != null
+            ? runContext.render(this.fieldValues).asMap(String.class, Object.class)
+            : Map.<String, Object>of();
+
+        if (!renderedFieldValues.isEmpty()) {
+            setFieldValues(runContext, issue, renderedFieldValues);
+        }
+
         return Output
             .builder()
             .issueUrl(issue.getHtmlUrl())
             .issueNumber(issue.getNumber())
             .build();
+    }
+
+    private void setFieldValues(RunContext runContext, GHIssue issue, Map<String, Object> fieldValues) throws Exception {
+        var token = resolveToken(runContext);
+        var rEndpoint = runContext.render(getEndpoint()).as(String.class)
+            .orElse("https://api.github.com");
+        var rRepository = runContext.render(this.repository).as(String.class).orElseThrow();
+
+        var url = "%s/repos/%s/issues/%d/field-values".formatted(
+            rEndpoint.stripTrailing(),
+            rRepository,
+            issue.getNumber()
+        );
+        var body = OBJECT_MAPPER.writeValueAsString(Map.of("field_values", fieldValues));
+
+        var request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
+            .PUT(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+
+        var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new RuntimeException(
+                "Failed to set field values on issue %s (HTTP %d): %s"
+                    .formatted(issue.getHtmlUrl(), response.statusCode(), response.body())
+            );
+        }
     }
 
     @Builder

--- a/src/main/java/io/kestra/plugin/github/issues/Create.java
+++ b/src/main/java/io/kestra/plugin/github/issues/Create.java
@@ -1,6 +1,9 @@
 package io.kestra.plugin.github.issues;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -18,10 +21,6 @@ import org.kohsuke.github.GitHub;
 
 import java.net.URI;
 import java.net.URL;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -221,7 +220,6 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
         var rRepository = runContext.render(this.repository).as(String.class).orElseThrow();
         var org = rRepository.split("/")[0];
 
-        // Resolve human-readable field names to node IDs when needed
         var resolvedFields = resolveFieldKeys(runContext, fields, token, rEndpoint, org);
 
         var url = "%s/repos/%s/issues/%d/field-values".formatted(
@@ -231,36 +229,32 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
         );
         var bodyJson = OBJECT_MAPPER.writeValueAsString(Map.of("field_values", resolvedFields));
 
-        try (var client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(30))
-                .build()) {
-            var request = HttpRequest.newBuilder()
+        var httpConfig = HttpConfiguration.builder().allowFailed(Property.ofValue(true)).build();
+        try (var client = new HttpClient(runContext, httpConfig)) {
+            var request = HttpRequest.builder()
                 .uri(URI.create(url))
-                .method("PUT", HttpRequest.BodyPublishers.ofString(bodyJson))
-                .header("Authorization", "Bearer " + token)
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
-                .timeout(Duration.ofSeconds(30))
+                .method("PUT")
+                .body(HttpRequest.StringRequestBody.builder().content(bodyJson).build())
+                .addHeader("Authorization", "Bearer " + token)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/vnd.github+json")
+                .addHeader("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
                 .build();
-            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            var response = client.request(request, String.class);
+            var status = response.getStatus().getCode();
+            if (status < 200 || status >= 300) {
+                var body = response.getBody();
                 runContext.logger().error("Failed to set field values on issue {} (HTTP {}): {}",
-                    issue.getHtmlUrl(), response.statusCode(),
-                    response.body().length() > 500 ? response.body().substring(0, 500) + "…" : response.body());
+                    issue.getHtmlUrl(), status,
+                    body != null && body.length() > 500 ? body.substring(0, 500) + "…" : body);
                 throw new RuntimeException(
                     "Failed to set field values on issue %s (HTTP %d) — see execution logs for details"
-                        .formatted(issue.getHtmlUrl(), response.statusCode())
+                        .formatted(issue.getHtmlUrl(), status)
                 );
             }
         }
     }
 
-    /**
-     * For each key in the input map: if it looks like a node ID (length > 20 and contains only
-     * ASCII letters, digits, underscores, hyphens), pass it through unchanged. Otherwise treat it
-     * as a human-readable name and resolve it to a field node ID via the GitHub API.
-     */
     private Map<String, Object> resolveFieldKeys(
             RunContext runContext,
             Map<String, Object> fields,
@@ -294,50 +288,45 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
     }
 
     private static boolean looksLikeNodeId(String key) {
+        // node IDs are >20 chars of [A-Za-z0-9_-]
         return key.length() > 20 && key.chars().allMatch(c ->
             (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
             (c >= '0' && c <= '9') || c == '_' || c == '-'
         );
     }
 
-    /**
-     * Fetches field definitions from the GitHub org-level REST endpoint. Falls back to GraphQL
-     * if the REST endpoint returns 404. Throws if neither endpoint provides definitions.
-     */
     private Map<String, String> fetchFieldDefinitions(
             RunContext runContext,
             String token,
             String endpoint,
             String org) throws Exception {
 
-        try (var client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(30))
-                .build()) {
-
+        var httpConfig = HttpConfiguration.builder().allowFailed(Property.ofValue(true)).build();
+        try (var client = new HttpClient(runContext, httpConfig)) {
             var restUrl = "%s/orgs/%s/issues/field-definitions".formatted(endpoint.stripTrailing(), org);
-            var restRequest = HttpRequest.newBuilder()
+            var restRequest = HttpRequest.builder()
                 .uri(URI.create(restUrl))
-                .GET()
-                .header("Authorization", "Bearer " + token)
-                .header("Accept", "application/vnd.github+json")
-                .header("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
-                .timeout(Duration.ofSeconds(30))
+                .method("GET")
+                .addHeader("Authorization", "Bearer " + token)
+                .addHeader("Accept", "application/vnd.github+json")
+                .addHeader("X-GitHub-Api-Version", FIELD_VALUES_API_VERSION)
                 .build();
-            var restResponse = client.send(restRequest, HttpResponse.BodyHandlers.ofString());
+            var restResponse = client.request(restRequest, String.class);
+            var restStatus = restResponse.getStatus().getCode();
 
-            if (restResponse.statusCode() == 200) {
-                return parseRestFieldDefinitions(restResponse.body());
+            if (restStatus == 200) {
+                return parseRestFieldDefinitions(restResponse.getBody());
             }
 
-            if (restResponse.statusCode() == 404) {
+            if (restStatus == 404) {
                 runContext.logger().debug(
                     "Field definitions REST endpoint not available for org '{}', trying GraphQL fallback", org);
-                return fetchFieldDefinitionsViaGraphQL(client, token, endpoint, org);
+                return fetchFieldDefinitionsViaGraphQL(runContext, client, token, endpoint, org);
             }
 
             throw new IllegalArgumentException(
                 "Cannot resolve field name: field definitions endpoint returned HTTP %d for organization '%s'. Use the field node ID directly (e.g. PVTF_…)."
-                    .formatted(restResponse.statusCode(), org)
+                    .formatted(restStatus, org)
             );
         }
     }
@@ -357,35 +346,43 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
     }
 
     private Map<String, String> fetchFieldDefinitionsViaGraphQL(
+            RunContext runContext,
             HttpClient client,
             String token,
             String endpoint,
             String org) throws Exception {
 
-        var graphqlEndpoint = endpoint.contains("api.github.com")
-            ? "https://api.github.com/graphql"
-            : endpoint.stripTrailing() + "/graphql";
+        var graphqlUrl = endpoint.stripTrailing() + "/graphql";
         var query = OBJECT_MAPPER.writeValueAsString(Map.of(
             "query", "query($org: String!) { organization(login: $org) { issueTypes { nodes { id name } } } }",
             "variables", Map.of("org", org)
         ));
-        var graphqlRequest = HttpRequest.newBuilder()
-            .uri(URI.create(graphqlEndpoint))
-            .POST(HttpRequest.BodyPublishers.ofString(query))
-            .header("Authorization", "Bearer " + token)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json")
-            .timeout(Duration.ofSeconds(30))
+        var graphqlRequest = HttpRequest.builder()
+            .uri(URI.create(graphqlUrl))
+            .method("POST")
+            .body(HttpRequest.StringRequestBody.builder().content(query).build())
+            .addHeader("Authorization", "Bearer " + token)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("Accept", "application/json")
             .build();
-        var graphqlResponse = client.send(graphqlRequest, HttpResponse.BodyHandlers.ofString());
+        var graphqlResponse = client.request(graphqlRequest, String.class);
+        var graphqlStatus = graphqlResponse.getStatus().getCode();
 
-        if (graphqlResponse.statusCode() == 404) {
+        if (graphqlStatus == 404) {
             throw new IllegalArgumentException(
                 "Cannot resolve field name: field definitions are not available for organization '%s'. Use the field node ID directly (e.g. PVTF_…).".formatted(org)
             );
         }
 
-        var root = OBJECT_MAPPER.readTree(graphqlResponse.body());
+        if (graphqlStatus != 200) {
+            runContext.logger().error("GraphQL field-definitions lookup returned HTTP {}: {}",
+                graphqlStatus, graphqlResponse.getBody());
+            throw new IllegalArgumentException(
+                "GraphQL endpoint returned HTTP " + graphqlStatus + " — see execution logs"
+            );
+        }
+
+        var root = OBJECT_MAPPER.readTree(graphqlResponse.getBody());
         var nodes = root.path("data").path("organization").path("issueTypes").path("nodes");
         var result = new HashMap<String, String>();
         for (var node : nodes) {

--- a/src/main/java/io/kestra/plugin/github/issues/Create.java
+++ b/src/main/java/io/kestra/plugin/github/issues/Create.java
@@ -191,12 +191,12 @@ public class Create extends AbstractGithubTask implements RunnableTask<Create.Ou
 
         GHIssue issue = issueBuilder.create();
 
-        var renderedFieldValues = this.fieldValues != null
+        var rFieldValues = this.fieldValues != null
             ? runContext.render(this.fieldValues).asMap(String.class, Object.class)
             : Map.<String, Object>of();
 
-        if (!renderedFieldValues.isEmpty()) {
-            setFieldValues(runContext, issue, renderedFieldValues);
+        if (!rFieldValues.isEmpty()) {
+            setFieldValues(runContext, issue, rFieldValues);
         }
 
         return Output

--- a/src/test/java/io/kestra/plugin/github/MockController.java
+++ b/src/test/java/io/kestra/plugin/github/MockController.java
@@ -100,6 +100,17 @@ public class MockController {
             """);
     }
 
+    @Get("/orgs/kestra-io/issues/field-definitions")
+    public HttpResponse<String> getOrgFieldDefinitions(HttpRequest<?> request) {
+        capture(request);
+        return HttpResponse.ok("""
+            [
+              {"id": "PVTF_customer_node_id", "name": "Customer"},
+              {"id": "PVTF_stage_node_id", "name": "Stage"}
+            ]
+            """);
+    }
+
     @Put("/repos/kestra-io/mock-kestra/issues/42/field-values")
     public HttpResponse<String> setIssueFieldValues(HttpRequest<?> request, @Body String data) {
         capture(request);

--- a/src/test/java/io/kestra/plugin/github/MockController.java
+++ b/src/test/java/io/kestra/plugin/github/MockController.java
@@ -100,6 +100,13 @@ public class MockController {
             """);
     }
 
+    @Put("/repos/kestra-io/mock-kestra/issues/42/field-values")
+    public HttpResponse<String> setIssueFieldValues(HttpRequest<?> request, @Body String data) {
+        capture(request);
+        MockController.data = data;
+        return HttpResponse.ok("{}");
+    }
+
     @Post("/repos/kestra-io/mock-kestra/issues/42/comments")
     public HttpResponse<String> createIssueComment(HttpRequest<?> request, @Body String data) {
         capture(request);

--- a/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
@@ -4,12 +4,15 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.github.AbstractGithubClientTest;
+import io.kestra.plugin.github.MockController;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 public class CreateTest extends AbstractGithubClientTest {
@@ -30,10 +33,69 @@ public class CreateTest extends AbstractGithubClientTest {
             .assignees(Property.ofValue(List.of("iNikitaGricenko")))
             .build();
 
-        Create.Output run = task.run(runContext);
+        var output = task.run(runContext);
 
-        assertThat(run.getIssueUrl()).isNotNull();
-        assertThat(run.getIssueNumber()).isNotNull();
-        assertThat(run.getIssueNumber()).isEqualTo(42);
+        assertThat(output.getIssueUrl()).isNotNull();
+        assertThat(output.getIssueNumber()).isNotNull();
+        assertThat(output.getIssueNumber()).isEqualTo(42);
+    }
+
+    @Test
+    void runWithFieldValues() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var task = Create.builder()
+            .oauthToken(Property.ofValue("test-token"))
+            .endpoint(Property.ofValue(embeddedServer.getURI().toString()))
+            .repository(Property.ofValue("kestra-io/mock-kestra"))
+            .title(Property.ofValue("Test Kestra Github plugin with field values"))
+            .body(Property.ofValue("Issue with custom field values"))
+            .fieldValues(Property.ofValue(Map.of("PVTF_lADOA", "high", "PVTF_lADOB", "2024-12-31")))
+            .build();
+
+        var output = task.run(runContext);
+
+        assertThat(output.getIssueNumber()).isEqualTo(42);
+        assertThat(MockController.data).contains("field_values");
+        assertThat(MockController.data).contains("PVTF_lADOA");
+        assertThat(MockController.headers).containsEntry("x-github-api-version", "2026-03-10");
+        assertThat(MockController.headers.get("authorization")).startsWith("Bearer ");
+    }
+
+    @Test
+    void runWithEmptyFieldValuesSkipsRestCall() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var task = Create.builder()
+            .oauthToken(Property.ofValue(""))
+            .endpoint(Property.ofValue(embeddedServer.getURI().toString()))
+            .repository(Property.ofValue("kestra-io/mock-kestra"))
+            .title(Property.ofValue("Test Kestra Github plugin"))
+            .body(Property.ofValue("Issue without field values"))
+            .fieldValues(Property.ofValue(Map.of()))
+            .build();
+
+        var output = task.run(runContext);
+
+        assertThat(output.getIssueNumber()).isEqualTo(42);
+        // field-values endpoint was never called, so data stays as set by createIssue mock
+        assertThat(MockController.data).doesNotContain("field_values");
+    }
+
+    @Test
+    void runWithFieldValuesButNoTokenThrows() {
+        var runContext = runContextFactory.of();
+
+        var task = Create.builder()
+            .endpoint(Property.ofValue(embeddedServer.getURI().toString()))
+            .repository(Property.ofValue("kestra-io/mock-kestra"))
+            .title(Property.ofValue("Test"))
+            .body(Property.ofValue("Body"))
+            .fieldValues(Property.ofValue(Map.of("PVTF_lADOA", "high")))
+            .build();
+
+        assertThatThrownBy(() -> task.run(runContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No GitHub token configured");
     }
 }

--- a/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
@@ -7,6 +7,8 @@ import io.kestra.plugin.github.AbstractGithubClientTest;
 import io.kestra.plugin.github.MockController;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class CreateTest extends AbstractGithubClientTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/github/issues/CreateTest.java
@@ -41,7 +41,7 @@ public class CreateTest extends AbstractGithubClientTest {
     }
 
     @Test
-    void runWithFieldValues() throws Exception {
+    void runWithFieldNodeIds() throws Exception {
         var runContext = runContextFactory.of();
 
         var task = Create.builder()
@@ -50,20 +50,42 @@ public class CreateTest extends AbstractGithubClientTest {
             .repository(Property.ofValue("kestra-io/mock-kestra"))
             .title(Property.ofValue("Test Kestra Github plugin with field values"))
             .body(Property.ofValue("Issue with custom field values"))
-            .fieldValues(Property.ofValue(Map.of("PVTF_lADOA", "high", "PVTF_lADOB", "2024-12-31")))
+            .fields(Property.ofValue(Map.of("PVTF_lADOAAAAAAAAAAAAAA", "high", "PVTF_lADOBBBBBBBBBBBBB", "2024-12-31")))
             .build();
 
         var output = task.run(runContext);
 
         assertThat(output.getIssueNumber()).isEqualTo(42);
         assertThat(MockController.data).contains("field_values");
-        assertThat(MockController.data).contains("PVTF_lADOA");
+        assertThat(MockController.data).contains("PVTF_lADOAAAAAAAAAAAAAA");
         assertThat(MockController.headers).containsEntry("x-github-api-version", "2026-03-10");
         assertThat(MockController.headers.get("authorization")).startsWith("Bearer ");
     }
 
     @Test
-    void runWithEmptyFieldValuesSkipsRestCall() throws Exception {
+    void runWithHumanReadableFieldNames() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var task = Create.builder()
+            .oauthToken(Property.ofValue("test-token"))
+            .endpoint(Property.ofValue(embeddedServer.getURI().toString()))
+            .repository(Property.ofValue("kestra-io/mock-kestra"))
+            .title(Property.ofValue("Test issue with human-readable field names"))
+            .body(Property.ofValue("Issue with field names resolved from org definitions"))
+            .fields(Property.ofValue(Map.of("Customer", "Kestra", "Stage", "In review")))
+            .build();
+
+        var output = task.run(runContext);
+
+        assertThat(output.getIssueNumber()).isEqualTo(42);
+        // Resolved node IDs from mock field-definitions endpoint must appear in the PUT body
+        assertThat(MockController.data).contains("field_values");
+        assertThat(MockController.data).contains("PVTF_customer_node_id");
+        assertThat(MockController.data).contains("PVTF_stage_node_id");
+    }
+
+    @Test
+    void runWithEmptyFieldsSkipsRestCall() throws Exception {
         var runContext = runContextFactory.of();
 
         var task = Create.builder()
@@ -72,7 +94,7 @@ public class CreateTest extends AbstractGithubClientTest {
             .repository(Property.ofValue("kestra-io/mock-kestra"))
             .title(Property.ofValue("Test Kestra Github plugin"))
             .body(Property.ofValue("Issue without field values"))
-            .fieldValues(Property.ofValue(Map.of()))
+            .fields(Property.ofValue(Map.of()))
             .build();
 
         var output = task.run(runContext);
@@ -83,7 +105,7 @@ public class CreateTest extends AbstractGithubClientTest {
     }
 
     @Test
-    void runWithFieldValuesButNoTokenThrows() {
+    void runWithFieldsButNoTokenThrows() {
         var runContext = runContextFactory.of();
 
         var task = Create.builder()
@@ -91,7 +113,7 @@ public class CreateTest extends AbstractGithubClientTest {
             .repository(Property.ofValue("kestra-io/mock-kestra"))
             .title(Property.ofValue("Test"))
             .body(Property.ofValue("Body"))
-            .fieldValues(Property.ofValue(Map.of("PVTF_lADOA", "high")))
+            .fields(Property.ofValue(Map.of("PVTF_lADOAAAAAAAAAAAAAA", "high")))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))


### PR DESCRIPTION
## Summary

- Add `fieldValues: Property<Map<String, Object>>` to `issues.Create` so users can set custom Issue Field values when creating an issue
- After `issueBuilder.create()` returns, if `fieldValues` is non-null and non-empty, a `PUT /repos/{owner}/{repo}/issues/{issueNumber}/field-values` call is made using JDK 21 `HttpClient` with `X-GitHub-Api-Version: 2026-03-10` (the kohsuke library does not cover this endpoint)
- Add `resolveToken(RunContext)` helper to `AbstractGithubTask` resolving the token with priority `oauthToken → appInstallationToken → jwtToken`; throws `IllegalStateException` when none is set and `fieldValues` requires a token
- Null or empty `fieldValues` skips the REST call entirely, preserving existing behavior
- Non-2xx response from the field-values endpoint throws `RuntimeException` with HTTP status, body, and issue URL
- Added a new `@Example` showing `fieldValues` usage; fixed the two pre-existing examples that were missing `full = true`

closes: https://github.com/kestra-io/plugin-github/issues/103

## Test plan

- [ ] `rtk test ./gradlew test` passes (all existing + 3 new tests in `CreateTest`)
- [ ] `runWithFieldValues` — verifies the PUT call reaches the mock, correct API-version header, and Bearer auth
- [ ] `runWithEmptyFieldValuesSkipsRestCall` — verifies the field-values endpoint is never called for an empty map
- [ ] `runWithFieldValuesButNoTokenThrows` — verifies `IllegalStateException` when no token is configured