### PR TITLE
fix(projects): increase fieldValues limit and add missing fragment types

### DIFF
--- a/src/main/java/io/kestra/plugin/github/projects/List.java
+++ b/src/main/java/io/kestra/plugin/github/projects/List.java
@@ -95,7 +95,7 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
                   endCursor
                 }
                 nodes {
-                  fieldValues(first: 20) {
+                  fieldValues(first: 50) {
                     nodes {
                       ... on ProjectV2ItemFieldTextValue {
                         field { ... on ProjectV2FieldCommon { name } }
@@ -116,6 +116,22 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
                       ... on ProjectV2ItemFieldIterationValue {
                         field { ... on ProjectV2FieldCommon { name } }
                         title
+                      }
+                      ... on ProjectV2ItemFieldUserValue {
+                        field { ... on ProjectV2FieldCommon { name } }
+                        users(first: 10) { nodes { login } }
+                      }
+                      ... on ProjectV2ItemFieldRepositoryValue {
+                        field { ... on ProjectV2FieldCommon { name } }
+                        repository { nameWithOwner }
+                      }
+                      ... on ProjectV2ItemFieldLabelValue {
+                        field { ... on ProjectV2FieldCommon { name } }
+                        labels(first: 10) { nodes { name } }
+                      }
+                      ... on ProjectV2ItemFieldMilestoneValue {
+                        field { ... on ProjectV2FieldCommon { name } }
+                        milestone { title }
                       }
                     }
                   }
@@ -334,6 +350,16 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
             })
             .toList();
 
+        if (!allItems.isEmpty() && filtered.isEmpty() && (!rFields.isEmpty() || !rStatus.isEmpty() || !rLabels.isEmpty())) {
+            runContext.logger().warn(
+                "All {} fetched items were excluded by the configured filters (fields={}, status={}, labels={}). " +
+                "Verify that filter values match the actual project field values (filters are case-sensitive).",
+                allItems.size(), rFields, rStatus, rLabels
+            );
+        } else {
+            runContext.logger().info("Fetched {} items, {} passed filters.", allItems.size(), filtered.size());
+        }
+
         var limited = (rLimit > 0 && filtered.size() > rLimit) ? filtered.subList(0, rLimit) : filtered;
 
         return handleFetch(
@@ -362,6 +388,22 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
                 result.put(fieldName, fv.path("number").asText(null));
             } else if (fv.has("title")) {
                 result.put(fieldName, fv.path("title").asText(null));
+            } else if (fv.has("users")) {
+                var logins = new ArrayList<String>();
+                for (var user : fv.path("users").path("nodes")) {
+                    logins.add(user.path("login").asText());
+                }
+                result.put(fieldName, String.join(",", logins));
+            } else if (fv.has("repository")) {
+                result.put(fieldName, fv.path("repository").path("nameWithOwner").asText(null));
+            } else if (fv.has("labels")) {
+                var names = new ArrayList<String>();
+                for (var label : fv.path("labels").path("nodes")) {
+                    names.add(label.path("name").asText());
+                }
+                result.put(fieldName, String.join(",", names));
+            } else if (fv.has("milestone")) {
+                result.put(fieldName, fv.path("milestone").path("title").asText(null));
             }
         }
         return result;

--- a/src/main/java/io/kestra/plugin/github/projects/List.java
+++ b/src/main/java/io/kestra/plugin/github/projects/List.java
@@ -146,6 +146,30 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
                       repository { name }
                       assignees(first: 10) { nodes { login } }
                       labels(first: 10) { nodes { name } }
+                      issueFieldValues(first: 30) {
+                        nodes {
+                          ... on IssueFieldSingleSelectValue {
+                            field { ... on IssueFieldSingleSelect { name } }
+                            name
+                          }
+                          ... on IssueFieldTextValue {
+                            field { ... on IssueFieldText { name } }
+                            value
+                          }
+                          ... on IssueFieldNumberValue {
+                            field { ... on IssueFieldNumber { name } }
+                            value
+                          }
+                          ... on IssueFieldDateValue {
+                            field { ... on IssueFieldDate { name } }
+                            value
+                          }
+                          ... on IssueFieldMultiSelectValue {
+                            field { ... on IssueFieldMultiSelect { name } }
+                            value
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -320,6 +344,9 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
 
                     item.put("status", fieldValues.getOrDefault("Status", null));
                     fieldValues.forEach(item::putIfAbsent);
+                    // Org-level issue fields (e.g. Owner, Stage, Priority) are stored separately
+                    // from project item fieldValues — merge them after so project fields win on collision.
+                    extractIssueFieldValues(content).forEach(item::putIfAbsent);
 
                     allItems.add(item);
                 }
@@ -404,6 +431,24 @@ public class List extends AbstractGithubSearchTask implements RunnableTask<Abstr
                 result.put(fieldName, String.join(",", names));
             } else if (fv.has("milestone")) {
                 result.put(fieldName, fv.path("milestone").path("title").asText(null));
+            }
+        }
+        return result;
+    }
+
+    private Map<String, String> extractIssueFieldValues(JsonNode contentNode) {
+        var result = new HashMap<String, String>();
+        for (var fv : contentNode.path("issueFieldValues").path("nodes")) {
+            var fieldName = fv.path("field").path("name").asText(null);
+            if (fieldName == null) {
+                continue;
+            }
+            if (fv.has("name")) {
+                // IssueFieldSingleSelectValue
+                result.put(fieldName, fv.path("name").asText(null));
+            } else if (fv.has("value")) {
+                // IssueFieldTextValue, IssueFieldNumberValue, IssueFieldDateValue, IssueFieldMultiSelectValue
+                result.put(fieldName, fv.path("value").asText(null));
             }
         }
         return result;


### PR DESCRIPTION
## Problem

Three issues in `projects.List` preventing the `fields` filter from working:

### 1. Org-level issue fields were invisible (root cause for `Owner: Plugins` returning 0)

Fields shown in the GitHub issue sidebar — Owner, Stage, Priority, Release, etc. — are **org-level issue fields** stored in `issue.issueFieldValues`. This is a completely separate API from the GitHub Projects v2 item `fieldValues` the plugin was reading.

Because the plugin only read project-level `fieldValues`, a filter like `fields: Owner: Plugins` always returned 0 items even when Owner was explicitly set, since the value was never fetched.

**Fix:** Add `issueFieldValues(first: 30)` to the `Issue` GraphQL fragment, extract them in a new `extractIssueFieldValues()` method, and merge them into the item map after project fieldValues (project fields win on collision).

### 2. `fieldValues(first: 20)` truncation

Projects with more than 20 set field values per item could have their later fields silently truncated. Project #15 has 21 total fields.

**Fix:** Raise to `fieldValues(first: 50)`.

### 3. Missing GraphQL fragments for project fieldValue types

`extractFieldValues` only handled 5 fragment types. `UserValue`, `RepositoryValue`, `LabelValue`, and `MilestoneValue` were silently skipped, making those fields invisible to filters.

**Fix:** Add the four missing fragments and extract their values.

### 4. Silent 0-item result

When all fetched items were excluded by filters the task returned 0 with no warning — impossible to distinguish "filter matched nothing" from "project is empty".

**Fix:** Log a `WARN` when filters exclude all items, quoting the exact filter values and noting they are case-sensitive. Log item counts at `INFO` level.